### PR TITLE
Add initial READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Backend Mono Repo
+
+This repository hosts a collection of backend services and shared libraries.  It is organised as a **pnpm** monorepo using **turborepo** for task orchestration.  At the moment it only contains a few skeleton packages and one service, but it serves as a starting point for a larger microservice architecture.
+
+## Folder structure
+
+```
+.
+├── docker/        # Docker compose files for local dependencies
+├── packages/      # Reusable packages shared across services
+│   ├── auth-mw/   # Authentication middleware (Fastify JWT)
+│   └── core/      # Core utilities (logger, helpers)
+├── services/      # Independent microservices
+│   └── user-auth/ # Fastify based authentication service
+├── package.json   # Root workspace scripts
+└── pnpm-workspace.yaml
+```
+
+- **packages/** holds libraries that can be versioned and published independently.
+- **services/** contains runnable applications. Each service can be developed and deployed separately.
+- **docker/** provides a `docker-compose` setup with Postgres and Redis for local development.
+
+## Getting started
+
+1. Install dependencies for all workspaces:
+
+   ```bash
+   pnpm install
+   ```
+
+2. Start development servers for all services:
+
+   ```bash
+   pnpm dev
+   ```
+
+   This runs the `dev` script in each service in parallel. Individual services can be started with `pnpm --filter <service> dev`.
+
+3. Build all services:
+
+   ```bash
+   pnpm build
+   ```
+
+## Current status
+
+The code base is still at an early stage. Many packages contain placeholders or empty files that will be fleshed out as development continues. See the README in each package or service for more details.
+

--- a/packages/auth-mw/README.md
+++ b/packages/auth-mw/README.md
@@ -1,0 +1,13 @@
+# `@mani-r16-devkit/auth-mw`
+
+Fastify middleware for handling JWT authentication.  The implementation is still
+minimal but will provide hooks for verifying tokens and protecting routes.
+
+## Scripts
+
+```bash
+pnpm --filter @mani-r16-devkit/auth-mw build   # compile TypeScript
+pnpm --filter @mani-r16-devkit/auth-mw test    # run unit tests
+```
+
+This package expects `fastify` and `@fastify/jwt` as peer dependencies.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,14 @@
+# `@mani-r16-devkit/core`
+
+Utilities and helpers shared across backend services.
+Currently this package only contains placeholder files but will eventually host
+things like logging wrappers and common response helpers.
+
+## Scripts
+
+```bash
+pnpm --filter @mani-r16-devkit/core build   # compile TypeScript
+pnpm --filter @mani-r16-devkit/core lint    # run ESLint (when implemented)
+```
+
+This package is published as part of the monorepo and can be imported by other packages or services.


### PR DESCRIPTION
## Summary
- document project structure and how to run the repo in a root README
- add READMEs for `auth-mw` and `core` packages

## Testing
- `pnpm install`
- `pnpm test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6880eb28d118832cb345e6ed97a1f22b