### PR TITLE
docs: improve docker usage and auth route examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A collection of backend services and shared packages built with **Fastify**. The
 - [Environment Variables](#environment-variables)
 - [Packages](#packages)
 - [Health Check](#health-check)
+- [Auth Service Routes](#auth-service-routes)
 - [Further Reading](#further-reading)
 
 ## Folder Structure
@@ -136,6 +137,26 @@ Response:
 
 ```json
 { "status": "ok", "data": { "uptime": 0 }, "meta": { "trace_id": null } }
+```
+
+## Auth Service Routes
+
+In addition to `/health` (shown above), the `user-auth` service exposes the following routes:
+
+```bash
+# Sign up a new user
+curl -X POST http://localhost:4000/v1/signup \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com","password":"secret","profile":{}}'
+
+# Log in to receive a token
+curl -X POST http://localhost:4000/v1/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com","password":"secret"}'
+
+# Get current user (requires JWT token)
+curl http://localhost:4000/v1/me \
+  -H "Authorization: Bearer <TOKEN>"
 ```
 
 ## Further Reading

--- a/services/user-auth/README.md
+++ b/services/user-auth/README.md
@@ -4,10 +4,10 @@ Fastify-based authentication service.
 
 ## Docker
 
-Run the authentication service together with its dependencies:
+Run all services together with their dependencies from the repository root:
 
 ```bash
-docker compose -f docker/docker-compose.dev.yml up --build user-auth
+docker compose -f docker/docker-compose.dev.yml up --build
 ```
 
 Troubleshoot the running container:


### PR DESCRIPTION
## Summary
- update docker compose usage to start all services from the repository root
- add cURL examples for auth service routes

## Testing
- `pnpm lint` *(fails: Parsing error: Unexpected token type)*
- `pnpm test` *(fails: packages/platform test: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a04db8fb60832c946d764fc4b6dcc4